### PR TITLE
Use MET bugfix version to fix python error when using python 3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "6.1.0" %}
-{% set met_version = "12.1.0" %}
+{% set met_version = "12.1.1" %}
 
 package:
   name: metplus
@@ -11,14 +11,14 @@ source:
     sha256: f79552f18d439e416dfa4f7cb65de9f1196864c5d3abf7443310ae4a154cc15f
 
   - url: https://github.com/dtcenter/MET/archive/refs/tags/v{{ met_version }}.tar.gz
-    md5: 972fdb929868e0f9d799af4ca9a4eeb2
-    sha256: c0d25ab44255f83e4dbc8f472eaa1cf44f5a05d8a6a260c5c4f1811f2da457c7
+    md5: 7118bcd1ed9762304f0b0335a1ab7d11
+    sha256: da242378932f3057a06cf96e53dcdf74612197f70753e4be32c6390c63056031
     folder: MET
 
 
 build:
   skip: true  # [win or py!=310]
-  number: 0
+  number: 1
   entry_points:
     - run_metplus.py = metplus.scripts.run_metplus:cli_main
   ignore_run_exports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

MET issue dtcenter/MET#3219 describes a bug when using MET's [Python Embedding](https://metplus.readthedocs.io/projects/met/en/latest/Users_Guide/appendixF.html) logic using Python 3.10. This recipe requires Python 3.10 due to the dependent library [nceplibs-bufr](https://github.com/conda-forge/nceplibs-bufr-feedstock) requiring Python 3.10. This was fixed with PR dtcenter/MET#3222 and included in MET 12.1.1 bugfix release. This PR updates the recipe to use this bugfix version to fix the issue.

<!--
Please add any other relevant info below:
-->
